### PR TITLE
Add field initializers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ crashlytics-build.properties
 /Assets/UdonSharp/Scripts/Editor/
 Assets/VRCSDK.meta
 Assets/UdonSharp/Scripts/Editor.meta
+.idea/*

--- a/Assets/UdonSharp/Editor/UdonSharpASTVisitor.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpASTVisitor.cs
@@ -416,10 +416,6 @@ namespace UdonSharp
                             symbolCreationScope.ExecuteSet(initializerCapture.ExecuteGet());
                         }
                     }
-                    else if (variableDeclarator.Initializer != null)
-                    {
-                        throw new System.NotImplementedException("UdonSharp does not yet support initializers on fields.");
-                    }
                 }
 
                 if (!createdSymbol)

--- a/Assets/UdonSharp/Editor/UdonSharpCompiler.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpCompiler.cs
@@ -1,7 +1,19 @@
-﻿using System.Collections;
+﻿using System;
+using System.CodeDom;
+using System.CodeDom.Compiler;
+using System.Collections;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Net.Http.Headers;
+using System.Reflection;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CSharp;
 using UnityEditor;
+using UnityEngine;
 using VRC.Udon.Common;
 using VRC.Udon.Common.Interfaces;
 
@@ -36,8 +48,95 @@ namespace UdonSharp
                         program.Heap.SetHeapVariable(symbolAddress, symbol.symbolDefaultValue, symbol.symbolCsType);
                     }
                 }
+
+                RunFieldInitalizers(program);
+            }
+        }
+
+        private void RunFieldInitalizers(IUdonProgram program)
+        {
+            CodeCompileUnit compileUnit = new CodeCompileUnit();
+            CodeNamespace ns = new CodeNamespace("FieldInitialzers");
+            compileUnit.Namespaces.Add(ns);
+            foreach (var resolverUsingNamespace in module.resolver.usingNamespaces)
+            {
+                if (!string.IsNullOrEmpty(resolverUsingNamespace))
+                    ns.Imports.Add(new CodeNamespaceImport(resolverUsingNamespace));
+            }
+
+            CodeTypeDeclaration _class = new CodeTypeDeclaration("Initializer");
+            ns.Types.Add(_class);
+            CodeMemberMethod method = new CodeMemberMethod();
+            _class.Members.Add(method);
+            method.Attributes = MemberAttributes.Public | MemberAttributes.Static;
+            method.ReturnType = new CodeTypeReference(typeof(void));
+            method.Name = "DoInit";
+            method.Parameters.Add(new CodeParameterDeclarationExpression(typeof(IUdonProgram), "program"));
+
+            foreach (var fieldDeclarationSyntax in module.fieldsWithInitializers)
+            {
+                var type = fieldDeclarationSyntax.Declaration.Type;
+                int count = 0;
+                foreach (var variable in fieldDeclarationSyntax.Declaration.Variables)
+                {
+                    var name = $"temp_{count}_{variable.Identifier}";
+                    method.Statements.Add(new CodeSnippetStatement($"{type} {name} {variable.Initializer};"));
+                    method.Statements.Add(new CodeSnippetStatement(
+                        $"program.Heap.SetHeapVariable(program.SymbolTable.GetAddressFromSymbol(\"{variable.Identifier}\"), {name});"));
+                    count++;
+                }
+            }
+
+            CSharpCodeProvider provider = new CSharpCodeProvider();
+            StringBuilder sb = new StringBuilder();
+            using (StringWriter streamWriter = new StringWriter(sb))
+            {
+                provider.GenerateCodeFromCompileUnit(compileUnit, streamWriter, new CodeGeneratorOptions());
+            }
+
+            SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(sb.ToString());
+
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            var references = new List<MetadataReference>();
+            for (int i = 0; i < assemblies.Length; i++)
+            {
+                if (!assemblies[i].IsDynamic)
+                    references.Add(MetadataReference.CreateFromFile(assemblies[i].Location));
+            }
+
+            CSharpCompilation compilation = CSharpCompilation.Create(
+                "init",
+                syntaxTrees: new[] {syntaxTree},
+                references: references,
+                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+            using (var memoryStream = new MemoryStream())
+            {
+                EmitResult result = compilation.Emit(memoryStream);
+                if (!result.Success)
+                {
+                    bool error = false;
+                    foreach (Diagnostic diagnostic in result.Diagnostics)
+                    {
+                        if (diagnostic.Severity == DiagnosticSeverity.Error)
+                        {
+                            Debug.LogError(diagnostic);
+                            error = true;
+                        }
+                    }
+
+                    if (error)
+                        Debug.LogError($"Generated Source code: {sb}");
+                }
+                else
+                {
+                    memoryStream.Seek(0, SeekOrigin.Begin);
+                    Assembly assembly = Assembly.Load(memoryStream.ToArray());
+                    var cls = assembly.GetType("FieldInitialzers.Initializer");
+                    MethodInfo methodInfo = cls.GetMethod("DoInit", BindingFlags.Public | BindingFlags.Static);
+                    methodInfo.Invoke(null, new[] {program});
+                }
             }
         }
     }
-
 }

--- a/Assets/UdonSharp/Editor/UdonSharpFieldRewriter.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpFieldRewriter.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using UnityEngine;
+
+public class UdonSharpFieldRewriter : CSharpSyntaxRewriter
+{
+    public HashSet<FieldDeclarationSyntax> fieldsWithInitializers;
+
+    public UdonSharpFieldRewriter(HashSet<FieldDeclarationSyntax> fieldsWithInitializers)
+    {
+        this.fieldsWithInitializers = fieldsWithInitializers;
+    }
+
+    public override SyntaxNode VisitFieldDeclaration(FieldDeclarationSyntax node)
+    {
+        var variables = node.Declaration.Variables;
+        foreach (var variable in node.Declaration.Variables)
+        {
+            if (variable.Initializer != null)
+            {
+                variables = variables.Replace(variable, variable.WithInitializer(null));
+                fieldsWithInitializers.Add(node);
+            }
+        }
+
+        return node.WithDeclaration(node.Declaration.WithVariables(variables));
+    }
+}

--- a/Assets/UdonSharp/Editor/UdonSharpFieldRewriter.cs.meta
+++ b/Assets/UdonSharp/Editor/UdonSharpFieldRewriter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4e6c185f13da1f247a47cc7845049d52
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Field initializers are now run at compile time from within C#. This also means you can do things that aren't possible in Udon in field initializers, assuming you don't have to import anything that doesn't exist in Udon.

For example this isn't possible in Udon, but works fine as a field in U#
`int foundIndex = (new System.Collections.Generic.List<int> { 3, 4 }).BinarySearch(4);`