### PR TITLE
User behaviour linking

### DIFF
--- a/Assets/UdonSharp/Editor/UdonSharpASTVisitor.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpASTVisitor.cs
@@ -1827,6 +1827,8 @@ namespace UdonSharp
             UpdateSyntaxNode(node);
 
             List<SymbolDefinition> invocationArgs = new List<SymbolDefinition>();
+            
+            //visitorContext.PushTable(new SymbolTable(visitorContext.resolverContext, visitorContext.topTable));
 
             foreach (ArgumentSyntax argument in node.ArgumentList.Arguments)
             {
@@ -1837,6 +1839,8 @@ namespace UdonSharp
                     invocationArgs.Add(captureScope.ExecuteGet());
                 }
             }
+
+            //visitorContext.PopTable();
             
             // Grab the external scope so that the method call can propagate its output upwards
             ExpressionCaptureScope externalScope = visitorContext.PopCaptureScope();

--- a/Assets/UdonSharp/Editor/UdonSharpASTVisitor.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpASTVisitor.cs
@@ -676,7 +676,7 @@ namespace UdonSharp
                 capturedType = typeCapture.captureType;
 
                 // Just throw a compile error for now instead of letting people get the typeof a type that won't exist in game
-                if (capturedType.IsSubclassOf(typeof(UdonSharpBehaviour)))
+                if (capturedType == typeof(UdonSharpBehaviour) || capturedType.IsSubclassOf(typeof(UdonSharpBehaviour)))
                     throw new System.NotSupportedException("UdonSharp does not currently support using `typeof` on user defined types");
             }
 

--- a/Assets/UdonSharp/Editor/UdonSharpASTVisitor.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpASTVisitor.cs
@@ -1686,6 +1686,7 @@ namespace UdonSharp
 
             JumpLabel loopExitLabel = visitorContext.labelTable.GetNewJumpLabel("foreachLoopExit");
             JumpLabel loopStartLabel = visitorContext.labelTable.GetNewJumpLabel("foreachLoopStart");
+            JumpLabel loopContinueLabel = visitorContext.labelTable.GetNewJumpLabel("foreachLoopContinue");
             visitorContext.uasmBuilder.AddJumpLabel(loopStartLabel);
 
             SymbolDefinition conditionSymbol = null;
@@ -1711,13 +1712,15 @@ namespace UdonSharp
                 }
             }
 
-            visitorContext.continueLabelStack.Push(loopStartLabel);
+            visitorContext.continueLabelStack.Push(loopContinueLabel);
             visitorContext.breakLabelStack.Push(loopExitLabel);
 
             Visit(node.Statement);
 
             visitorContext.continueLabelStack.Pop();
             visitorContext.breakLabelStack.Pop();
+
+            visitorContext.uasmBuilder.AddJumpLabel(loopContinueLabel);
 
             using (ExpressionCaptureScope incrementExecuteScope = new ExpressionCaptureScope(visitorContext, null))
             {

--- a/Assets/UdonSharp/Editor/UdonSharpASTVisitor.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpASTVisitor.cs
@@ -97,6 +97,8 @@ namespace UdonSharp
             visitorContext.returnJumpTarget = rootTable.CreateNamedSymbol("returnTarget", typeof(uint), SymbolDeclTypeFlags.Internal);
             visitorContext.definedMethods = methodDefinitions;
             visitorContext.externClassDefinitions = externUserClassDefinitions;
+
+            rootTable.visitorContext = visitorContext;
         }
 
         /// <summary>
@@ -214,7 +216,7 @@ namespace UdonSharp
         {
             UpdateSyntaxNode(node);
 
-            SymbolTable functionSymbolTable = new SymbolTable(visitorContext.resolverContext, visitorContext.topTable);
+            SymbolTable functionSymbolTable = new SymbolTable(visitorContext.resolverContext, visitorContext.topTable, visitorContext);
             visitorContext.PushTable(functionSymbolTable);
 
             foreach (StatementSyntax statement in node.Statements)
@@ -961,7 +963,7 @@ namespace UdonSharp
             if (!visitorContext.topTable.IsGlobalSymbolTable)
                 throw new System.Exception("Parent symbol table for method table must be the global symbol table.");
 
-            SymbolTable functionSymbolTable = new SymbolTable(visitorContext.resolverContext, visitorContext.topTable);
+            SymbolTable functionSymbolTable = new SymbolTable(visitorContext.resolverContext, visitorContext.topTable, visitorContext);
 
             // Setup local symbols for the user to read from, this prevents potential conflicts with other methods that have the same argument names
             foreach (ParameterDefinition paramDef in definition.parameters)
@@ -1608,7 +1610,7 @@ namespace UdonSharp
         {
             UpdateSyntaxNode(node);
 
-            SymbolTable forEachSymbolTable = new SymbolTable(visitorContext.resolverContext, visitorContext.topTable);
+            SymbolTable forEachSymbolTable = new SymbolTable(visitorContext.resolverContext, visitorContext.topTable, visitorContext);
             visitorContext.PushTable(forEachSymbolTable);
 
             System.Type valueSymbolType = null;

--- a/Assets/UdonSharp/Editor/UdonSharpASTVisitor.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpASTVisitor.cs
@@ -578,6 +578,10 @@ namespace UdonSharp
                 Visit(node.Type);
 
                 capturedType = typeCapture.captureType;
+
+                // Just throw a compile error for now instead of letting people get the typeof a type that won't exist in game
+                if (capturedType.IsSubclassOf(typeof(UdonSharpBehaviour)))
+                    throw new System.NotSupportedException("UdonSharp does not currently support using `typeof` on user defined types");
             }
 
             if (visitorContext.topCaptureScope != null)

--- a/Assets/UdonSharp/Editor/UdonSharpASTVisitor.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpASTVisitor.cs
@@ -601,7 +601,9 @@ namespace UdonSharp
             if (newSymbol != null)
                 VerifySyncValidForType(newSymbol.symbolCsType, syncMode);
 
-            bool isUserDefinedType = variableType.IsSubclassOf(typeof(UdonSharpBehaviour)) || (variableType.IsArray && variableType.GetElementType().IsSubclassOf(typeof(UdonSharpBehaviour)));
+            bool isUserDefinedType = variableType == typeof(UdonSharpBehaviour) || 
+                                     variableType.IsSubclassOf(typeof(UdonSharpBehaviour)) || 
+                                     (variableType.IsArray && (variableType.GetElementType().IsSubclassOf(typeof(UdonSharpBehaviour)) || variableType.GetElementType() == typeof(UdonSharpBehaviour)));
 
             if (!visitorContext.resolverContext.ValidateUdonTypeName(udonTypeName, UdonReferenceType.Variable) &&
                 !visitorContext.resolverContext.ValidateUdonTypeName(udonTypeName, UdonReferenceType.Type) &&
@@ -1827,8 +1829,6 @@ namespace UdonSharp
             UpdateSyntaxNode(node);
 
             List<SymbolDefinition> invocationArgs = new List<SymbolDefinition>();
-            
-            //visitorContext.PushTable(new SymbolTable(visitorContext.resolverContext, visitorContext.topTable));
 
             foreach (ArgumentSyntax argument in node.ArgumentList.Arguments)
             {
@@ -1839,8 +1839,6 @@ namespace UdonSharp
                     invocationArgs.Add(captureScope.ExecuteGet());
                 }
             }
-
-            //visitorContext.PopTable();
             
             // Grab the external scope so that the method call can propagate its output upwards
             ExpressionCaptureScope externalScope = visitorContext.PopCaptureScope();

--- a/Assets/UdonSharp/Editor/UdonSharpClass.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpClass.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 
 namespace UdonSharp
 {
+    [System.Serializable]
     public class FieldDefinition
     {
         public FieldDefinition(SymbolDefinition symbol)
@@ -15,6 +16,20 @@ namespace UdonSharp
         public SymbolDefinition fieldSymbol;
 
         public List<System.Attribute> fieldAttributes;
+
+        public T GetAttribute<T>() where T : System.Attribute
+        {
+            System.Type attributeType = typeof(T);
+
+            foreach (var attribute in fieldAttributes)
+            {
+                if (attribute.GetType() == attributeType)
+                    return attribute as T;
+            }
+
+            return null;
+        }
+
     }
 
     public class ClassDefinition

--- a/Assets/UdonSharp/Editor/UdonSharpClass.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpClass.cs
@@ -9,9 +9,12 @@ namespace UdonSharp
         public FieldDefinition(SymbolDefinition symbol)
         {
             fieldSymbol = symbol;
+            fieldAttributes = new List<System.Attribute>();
         }
 
         public SymbolDefinition fieldSymbol;
+
+        public List<System.Attribute> fieldAttributes;
     }
 
     public class ClassDefinition

--- a/Assets/UdonSharp/Editor/UdonSharpClass.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpClass.cs
@@ -1,0 +1,25 @@
+﻿
+
+using System.Collections.Generic;
+
+namespace UdonSharp
+{
+    public class FieldDefinition
+    {
+        public FieldDefinition(SymbolDefinition symbol)
+        {
+            fieldSymbol = symbol;
+        }
+
+        public SymbolDefinition fieldSymbol;
+    }
+
+    public class ClassDefinition
+    {
+        // Methods and fields should *not* be reflected off of this type, it is not guaranteed to be up to date
+        public System.Type userClassType;
+
+        public List<FieldDefinition> fieldDefinitions = new List<FieldDefinition>();
+        public List<MethodDefinition> methodDefinitions = new List<MethodDefinition>();
+    }
+}

--- a/Assets/UdonSharp/Editor/UdonSharpClass.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpClass.cs
@@ -16,6 +16,8 @@ namespace UdonSharp
         public SymbolDefinition fieldSymbol;
 
         public List<System.Attribute> fieldAttributes;
+        
+        public UnityEditor.MonoScript userBehaviourSource;
 
         public T GetAttribute<T>() where T : System.Attribute
         {

--- a/Assets/UdonSharp/Editor/UdonSharpClass.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpClass.cs
@@ -36,6 +36,7 @@ namespace UdonSharp
     {
         // Methods and fields should *not* be reflected off of this type, it is not guaranteed to be up to date
         public System.Type userClassType;
+        public UnityEditor.MonoScript classScript;
 
         public List<FieldDefinition> fieldDefinitions = new List<FieldDefinition>();
         public List<MethodDefinition> methodDefinitions = new List<MethodDefinition>();

--- a/Assets/UdonSharp/Editor/UdonSharpClass.cs.meta
+++ b/Assets/UdonSharp/Editor/UdonSharpClass.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6be5cc5b10e92984794cdb2865d806f1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UdonSharp/Editor/UdonSharpClassVisitor.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpClassVisitor.cs
@@ -1,0 +1,102 @@
+﻿
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace UdonSharp
+{
+    public class ClassVisitor : CSharpSyntaxWalker
+    {
+        public ClassDefinition classDefinition { get; private set; }
+        private MethodVisitor methodVisitor;
+
+        private ASTVisitorContext visitorContext;
+
+        private int classCount = 0;
+
+        public ClassVisitor(ResolverContext resolver, SymbolTable rootTable, LabelTable labelTable)
+            : base(SyntaxWalkerDepth.Node)
+        {
+            visitorContext = new ASTVisitorContext(resolver, rootTable, labelTable);
+            methodVisitor = new MethodVisitor(resolver, rootTable, labelTable);
+
+            classDefinition = new ClassDefinition();
+        }
+
+        public override void VisitCompilationUnit(CompilationUnitSyntax node)
+        {
+            base.VisitCompilationUnit(node);
+
+            methodVisitor.Visit(node);
+
+            classDefinition.methodDefinitions = methodVisitor.definedMethods;
+        }
+
+        public override void VisitClassDeclaration(ClassDeclarationSyntax node)
+        {
+            if (++classCount > 1)
+                throw new System.NotSupportedException("Only one class declaration per file is currently supported by UdonSharp");
+
+            using (ExpressionCaptureScope classTypeCapture = new ExpressionCaptureScope(visitorContext, null))
+            {
+                classTypeCapture.ResolveAccessToken(node.Identifier.ValueText);
+
+                if (!classTypeCapture.IsType())
+                    throw new System.Exception($"User type {node.Identifier.ValueText} could not be found");
+
+                classDefinition.userClassType = classTypeCapture.captureType;
+            }
+
+            base.VisitClassDeclaration(node);
+        }
+
+        public override void VisitFieldDeclaration(FieldDeclarationSyntax node)
+        {
+            bool isPublic = node.Modifiers.HasModifier("public");
+
+            System.Type fieldType = null;
+
+            using (ExpressionCaptureScope fieldTypeCapture = new ExpressionCaptureScope(visitorContext, null))
+            {
+                Visit(node.Declaration.Type);
+
+                fieldType = fieldTypeCapture.captureType;
+            }
+
+            foreach (VariableDeclaratorSyntax variableDeclarator in node.Declaration.Variables)
+            {
+                SymbolDefinition newSymbol = visitorContext.topTable.CreateNamedSymbol(variableDeclarator.Identifier.ValueText, fieldType, isPublic ? SymbolDeclTypeFlags.Public : SymbolDeclTypeFlags.Private);
+
+                classDefinition.fieldDefinitions.Add(new FieldDefinition(newSymbol));
+            }
+        }
+
+        #region Resolution boilerplate
+        // Boilerplate to have resolution work correctly
+        public override void VisitUsingDirective(UsingDirectiveSyntax node)
+        {
+            using (ExpressionCaptureScope namespaceCapture = new ExpressionCaptureScope(visitorContext, null))
+            {
+                Visit(node.Name);
+
+                if (!namespaceCapture.IsNamespace())
+                    throw new System.Exception("Did not capture a valid namespace");
+
+                visitorContext.resolverContext.AddNamespace(namespaceCapture.captureNamespace);
+            }
+        }
+
+        public override void VisitIdentifierName(IdentifierNameSyntax node)
+        {
+            if (visitorContext.topCaptureScope != null)
+                visitorContext.topCaptureScope.ResolveAccessToken(node.Identifier.ValueText);
+        }
+
+        public override void VisitPredefinedType(PredefinedTypeSyntax node)
+        {
+            if (visitorContext.topCaptureScope != null)
+                visitorContext.topCaptureScope.ResolveAccessToken(node.Keyword.ValueText);
+        }
+        #endregion
+    }
+}

--- a/Assets/UdonSharp/Editor/UdonSharpClassVisitor.cs.meta
+++ b/Assets/UdonSharp/Editor/UdonSharpClassVisitor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e85873fe83c69ed4180501ee2e181899
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UdonSharp/Editor/UdonSharpCompilationModule.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpCompilationModule.cs
@@ -102,6 +102,8 @@ namespace UdonSharp
             programAsset.SetUdonAssembly(dataBlock + codeBlock);
             programAsset.AssembleCsProgram();
 
+            programAsset.fieldDefinitions = visitor.visitorContext.localFieldDefinitions;
+
             return errorCount;
         }
 

--- a/Assets/UdonSharp/Editor/UdonSharpCompiler.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpCompiler.cs
@@ -246,6 +246,7 @@ namespace UdonSharp
                     return null;
                 }
 
+                classVisitor.classDefinition.classScript = udonSharpProgram.sourceCsScript;
                 classDefinitions.Add(classVisitor.classDefinition);
             }
 

--- a/Assets/UdonSharp/Editor/UdonSharpCompiler.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpCompiler.cs
@@ -49,7 +49,7 @@ namespace UdonSharp
                 {
                     EditorUtility.DisplayProgressBar("UdonSharp Compile",
                                                     $"Compiling {AssetDatabase.GetAssetPath(module.programAsset.sourceCsScript)}...",
-                                                    Mathf.Clamp01((moduleCounter++ / (float)modules.Length) + Random.Range(0.01f, 0.2f))); // Make it look like we're doing work :D
+                                                    Mathf.Clamp01((moduleCounter++ / (float)modules.Length) + Random.Range(0.01f, 1f / modules.Length))); // Make it look like we're doing work :D
 
                     int moduleErrorCount = module.Compile(classDefinitions);
                     totalErrorCount += moduleErrorCount;

--- a/Assets/UdonSharp/Editor/UdonSharpEditorAssembly.asmdef
+++ b/Assets/UdonSharp/Editor/UdonSharpEditorAssembly.asmdef
@@ -1,0 +1,19 @@
+{
+    "name": "UdonSharp.Editor",
+    "references": [
+        "VRC.Udon",
+        "VRC.Udon.Editor",
+        "UdonSharp.Runtime",
+        "VRC.Udon.Serialization.OdinSerializer"
+    ],
+    "optionalUnityReferences": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": []
+}

--- a/Assets/UdonSharp/Editor/UdonSharpEditorAssembly.asmdef
+++ b/Assets/UdonSharp/Editor/UdonSharpEditorAssembly.asmdef
@@ -12,8 +12,16 @@
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
-    "precompiledReferences": [],
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "Microsoft.CodeAnalysis.dll",
+        "Microsoft.CodeAnalysis.CSharp.dll",
+        "VRC.Udon.Common.dll",
+        "VRC.Udon.Graph.dll",
+        "VRCSDK3.dll",
+        "VRCSDKBase.dll",
+        "System.Collections.Immutable.dll"
+    ],
     "autoReferenced": true,
     "defineConstraints": []
 }

--- a/Assets/UdonSharp/Editor/UdonSharpEditorAssembly.asmdef.meta
+++ b/Assets/UdonSharp/Editor/UdonSharpEditorAssembly.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 84265b35cca3905448e623ef3903f0ff
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UdonSharp/Editor/UdonSharpExpressionCapture.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpExpressionCapture.cs
@@ -19,6 +19,8 @@ namespace UdonSharp
         This, // this.<next token> indicates that this must be a local symbol or method
         Enum,
         LocalMethod,
+        ExternUserField,
+        ExternUserMethod,
     }
 
     /// <summary>
@@ -48,6 +50,8 @@ namespace UdonSharp
         public System.Type captureType { get; private set; } = null;
         public string captureEnum { get; private set; } = "";
         public MethodDefinition captureLocalMethod { get; private set; } = null;
+        public FieldDefinition captureExternUserField { get; private set; } = null;
+        public MethodDefinition captureExternUserMethod { get; private set; } = null;
 
         private SymbolDefinition accessSymbol = null;
 
@@ -182,7 +186,9 @@ namespace UdonSharp
 
         public bool IsMethod()
         {
-            return captureArchetype == ExpressionCaptureArchetype.Method || captureArchetype == ExpressionCaptureArchetype.LocalMethod;
+            return captureArchetype == ExpressionCaptureArchetype.Method || 
+                   captureArchetype == ExpressionCaptureArchetype.LocalMethod || 
+                   captureArchetype == ExpressionCaptureArchetype.ExternUserMethod;
         }
 
         public bool IsProperty()
@@ -192,7 +198,8 @@ namespace UdonSharp
 
         public bool IsField()
         {
-            return captureArchetype == ExpressionCaptureArchetype.Field;
+            return captureArchetype == ExpressionCaptureArchetype.Field ||
+                   captureArchetype == ExpressionCaptureArchetype.ExternUserField;
         }
 
         public bool IsType()
@@ -292,6 +299,18 @@ namespace UdonSharp
                 visitorContext.uasmBuilder.AddPush(outSymbol);
                 visitorContext.uasmBuilder.AddExternCall(fieldAccessorUdonName);
             }
+            else if (captureArchetype == ExpressionCaptureArchetype.ExternUserField)
+            {
+                outSymbol = visitorContext.topTable.CreateUnnamedSymbol(captureExternUserField.fieldSymbol.symbolCsType, SymbolDeclTypeFlags.Internal);
+
+                using (ExpressionCaptureScope getVariableMethodScope = new ExpressionCaptureScope(visitorContext, null))
+                {
+                    getVariableMethodScope.SetToLocalSymbol(accessSymbol);
+                    getVariableMethodScope.ResolveAccessToken("GetProgramVariable");
+
+                    outSymbol = getVariableMethodScope.Invoke(new SymbolDefinition[] { visitorContext.topTable.CreateConstSymbol(typeof(string), captureExternUserField.fieldSymbol.symbolUniqueName) });
+                }
+            }
             else if (captureArchetype == ExpressionCaptureArchetype.ArrayIndexer)
             {
                 System.Type elementType = null;
@@ -317,7 +336,7 @@ namespace UdonSharp
             }
             else if (captureArchetype == ExpressionCaptureArchetype.This)
             {
-                outSymbol = visitorContext.topTable.CreateThisSymbol(typeof(VRC.Udon.UdonBehaviour));
+                outSymbol = visitorContext.topTable.CreateThisSymbol(visitorContext.behaviourUserType);
             }
             else if (captureArchetype == ExpressionCaptureArchetype.Enum)
             {
@@ -334,7 +353,7 @@ namespace UdonSharp
 
         public void ExecuteSet(SymbolDefinition value, bool explicitCast = false)
         {
-            SymbolDefinition convertedValue = CastSymbolToType(value, GetReturnType(), explicitCast);
+            SymbolDefinition convertedValue = CastSymbolToType(value, GetReturnType(true), explicitCast);
 
             // If it's a local symbol, it's just a simple COPY
             if (captureArchetype == ExpressionCaptureArchetype.LocalSymbol)
@@ -371,6 +390,19 @@ namespace UdonSharp
                 visitorContext.uasmBuilder.AddPush(convertedValue);
                 visitorContext.uasmBuilder.AddExternCall(fieldSetterUdonName);
             }
+            else if (captureArchetype == ExpressionCaptureArchetype.ExternUserField)
+            {
+                using (ExpressionCaptureScope setVariableMethodScope = new ExpressionCaptureScope(visitorContext, null))
+                {
+                    setVariableMethodScope.SetToLocalSymbol(accessSymbol);
+                    setVariableMethodScope.ResolveAccessToken("SetProgramVariable");
+
+                    setVariableMethodScope.Invoke(new SymbolDefinition[] {
+                        visitorContext.topTable.CreateConstSymbol(typeof(string), captureExternUserField.fieldSymbol.symbolUniqueName),
+                        convertedValue
+                    });
+                }
+            }
             else if (captureArchetype == ExpressionCaptureArchetype.ArrayIndexer)
             {
                 string setIndexerUdonName = visitorContext.resolverContext.GetUdonMethodName(accessSymbol.symbolCsType.GetMethods(BindingFlags.Public | BindingFlags.Instance).Where(e => e.Name == "Set").First());
@@ -389,20 +421,26 @@ namespace UdonSharp
         // There's probably a better place for this function...
         private SymbolDefinition CastSymbolToType(SymbolDefinition sourceSymbol, System.Type targetType, bool isExplicit)
         {
+            if (targetType.IsByRef) // Convert ref and out args to their main types.
+                targetType = targetType.GetElementType();
+
+            // Special case for passing through user defined classes if they match
+            if (sourceSymbol.IsUserDefinedBehaviour() && 
+                targetType.IsAssignableFrom(sourceSymbol.userCsType))
+                return sourceSymbol;
+            
             // Special case for assigning objects to non-value types so we can assign and the output of things that return a generic object
             // This lets the user potentially break their stuff if they assign an object return value from some function to a heap variable with a non-matching type. 
             // For instance you could assign a Transform component to a Renderer component variable, and you'd only realize the error when you tried to treat the Renderer as a Renderer.
             // This can't be trivially type checked at runtime with what Udon exposes in System.Type at the moment.
             bool isObjectAssignable = !targetType.IsValueType && sourceSymbol.symbolCsType == typeof(object);
-            if (targetType.IsByRef) // Convert ref and out args to their main types.
-                targetType = targetType.GetElementType();
 
             bool isNumericCastValid = UdonSharpUtils.IsNumericImplicitCastValid(targetType, sourceSymbol.symbolCsType) ||
                  (sourceSymbol.declarationType.HasFlag(SymbolDeclTypeFlags.Constant) && sourceSymbol.symbolCsType == typeof(int)); // Handle Roslyn giving us ints constant expressions
 
-            if ((!isExplicit && !targetType.IsImplicitlyAssignableFrom(sourceSymbol.symbolCsType)) &&
+            if ((!isExplicit && !targetType.IsImplicitlyAssignableFrom(sourceSymbol.userCsType)) &&
                 !isObjectAssignable && !isNumericCastValid)
-                throw new System.ArgumentException($"Cannot implicitly cast from {sourceSymbol.symbolCsType} to {targetType}");
+                throw new System.ArgumentException($"Cannot implicitly cast from {sourceSymbol.userCsType} to {targetType}");
 
             // Exact type match, just return the symbol, this is what will happen a majority of the time.
             if (targetType == sourceSymbol.symbolCsType || isObjectAssignable)
@@ -689,6 +727,14 @@ namespace UdonSharp
             return captureLocalMethod.returnSymbol;
         }
 
+        private SymbolDefinition InvokeUserExtern(SymbolDefinition[] invokeParams)
+        {
+            if (invokeParams.Length != captureExternUserMethod.parameters.Length)
+                throw new System.NotSupportedException("UdonSharp custom methods currently do not support default arguments or params arguments");
+
+            throw new System.NotImplementedException();
+        }
+
         public SymbolDefinition Invoke(SymbolDefinition[] invokeParams)
         {
             if (captureArchetype != ExpressionCaptureArchetype.Method && captureArchetype != ExpressionCaptureArchetype.LocalMethod)
@@ -700,19 +746,30 @@ namespace UdonSharp
             {
                 return InvokeExtern(invokeParams);
             }
-            else
+            else if (captureArchetype == ExpressionCaptureArchetype.LocalMethod)
             {
                 return InvokeLocalMethod(invokeParams);
             }
+            else if (captureArchetype == ExpressionCaptureArchetype.ExternUserMethod)
+            {
+                return InvokeUserExtern(invokeParams);
+            }
+            else
+            {
+                throw new System.Exception($"Cannot call invoke on archetype {captureArchetype}");
+            }
         }
 
-        public System.Type GetReturnType()
+        public System.Type GetReturnType(bool getUserType = false)
         {
             if (captureArchetype == ExpressionCaptureArchetype.Method)
                 throw new System.Exception("Cannot infer return type from method without function arguments");
 
             if (captureArchetype == ExpressionCaptureArchetype.LocalSymbol)
             {
+                if (getUserType)
+                    return accessSymbol.userCsType;
+
                 return accessSymbol.symbolCsType;
             }
             else if (captureArchetype == ExpressionCaptureArchetype.Property)
@@ -722,6 +779,13 @@ namespace UdonSharp
             else if (captureArchetype == ExpressionCaptureArchetype.Field)
             {
                 return captureField.FieldType;
+            }
+            else if (captureArchetype == ExpressionCaptureArchetype.ExternUserField)
+            {
+                if (getUserType)
+                    return captureExternUserField.fieldSymbol.userCsType;
+
+                return captureExternUserField.fieldSymbol.symbolCsType;
             }
             else if (captureArchetype == ExpressionCaptureArchetype.ArrayIndexer)
             {
@@ -772,7 +836,7 @@ namespace UdonSharp
                                 HandleStaticPropertyLookup(accessToken) ||
                                 HandleStaticFieldLookup(accessToken);
             }
-            else if (captureArchetype == ExpressionCaptureArchetype.Method)
+            else if (IsMethod())
             {
                 throw new System.InvalidOperationException("Cannot run an accessor on a method!");
             }
@@ -785,9 +849,11 @@ namespace UdonSharp
             else if (captureArchetype == ExpressionCaptureArchetype.LocalSymbol || 
                      captureArchetype == ExpressionCaptureArchetype.Property || 
                      captureArchetype == ExpressionCaptureArchetype.Field ||
+                     captureArchetype == ExpressionCaptureArchetype.ExternUserField ||
                      captureArchetype == ExpressionCaptureArchetype.ArrayIndexer)
             {
-                resolvedToken = HandleMemberPropertyAccess(accessToken) ||
+                resolvedToken = HandleExternUserFieldLookup(accessToken) ||
+                                HandleMemberPropertyAccess(accessToken) ||
                                 HandleMemberFieldAccess(accessToken) ||
                                 HandleMemberMethodLookup(accessToken);
             }
@@ -1131,11 +1197,35 @@ namespace UdonSharp
             return true;
         }
 
+        private bool HandleExternUserFieldLookup(string fieldToken)
+        {
+            if (!accessSymbol.IsUserDefinedBehaviour())
+                return false;
+
+            ClassDefinition externClass = visitorContext.externClassDefinitions.Where(e => e.userClassType == accessSymbol.userCsType).FirstOrDefault();
+
+            if (externClass == null)
+                return false;
+
+            FieldDefinition foundDefinition = externClass.fieldDefinitions.Where(e => e.fieldSymbol.symbolOriginalName == fieldToken).FirstOrDefault();
+
+            if (foundDefinition == null)
+                return false;
+
+            SymbolDefinition newAccessSymbol = ExecuteGet();
+
+            accessSymbol = newAccessSymbol;
+            captureArchetype = ExpressionCaptureArchetype.ExternUserField;
+            captureExternUserField = foundDefinition;
+
+            return true;
+        }
+
         public void HandleArrayIndexerAccess(SymbolDefinition indexerSymbol)
         {
             if (captureArchetype != ExpressionCaptureArchetype.LocalSymbol &&
                 captureArchetype != ExpressionCaptureArchetype.Property &&
-                captureArchetype != ExpressionCaptureArchetype.Field &&
+                !IsField() &&
                 captureArchetype != ExpressionCaptureArchetype.ArrayIndexer)
             {
                 throw new System.Exception("Can only run indexers on Local Symbols, Properties, Fields, and other indexers");

--- a/Assets/UdonSharp/Editor/UdonSharpExpressionCapture.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpExpressionCapture.cs
@@ -1251,7 +1251,7 @@ namespace UdonSharp
             if (externClass == null)
                 return false;
 
-            FieldDefinition foundDefinition = externClass.fieldDefinitions.Where(e => e.fieldSymbol.symbolOriginalName == fieldToken).FirstOrDefault();
+            FieldDefinition foundDefinition = externClass.fieldDefinitions.Where(e => e.fieldSymbol.symbolOriginalName == fieldToken && e.fieldSymbol.declarationType.HasFlag(SymbolDeclTypeFlags.Public)).FirstOrDefault();
 
             if (foundDefinition == null)
                 return false;
@@ -1275,7 +1275,7 @@ namespace UdonSharp
             if (externClass == null)
                 return false;
 
-            MethodDefinition foundDefinition = externClass.methodDefinitions.Where(e => e.originalMethodName == methodToken).FirstOrDefault();
+            MethodDefinition foundDefinition = externClass.methodDefinitions.Where(e => e.originalMethodName == methodToken && e.declarationFlags.HasFlag(MethodDeclFlags.Public)).FirstOrDefault();
 
             if (foundDefinition == null)
                 return false;

--- a/Assets/UdonSharp/Editor/UdonSharpExpressionCapture.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpExpressionCapture.cs
@@ -983,7 +983,7 @@ namespace UdonSharp
             if (foundMethods.Length == 0)
                 return false;
 
-            accessSymbol = visitorContext.topTable.CreateThisSymbol(typeof(VRC.Udon.UdonBehaviour));
+            accessSymbol = visitorContext.topTable.CreateThisSymbol(visitorContext.behaviourUserType);
             captureMethods = foundMethods;
             captureArchetype = ExpressionCaptureArchetype.Method;
 
@@ -1002,7 +1002,7 @@ namespace UdonSharp
             if (foundProperties.Length == 0)
                 return false;
 
-            accessSymbol = visitorContext.topTable.CreateThisSymbol(typeof(VRC.Udon.UdonBehaviour));
+            accessSymbol = visitorContext.topTable.CreateThisSymbol(visitorContext.behaviourUserType);
             captureProperty = foundProperties.First();
             captureArchetype = ExpressionCaptureArchetype.Property;
 

--- a/Assets/UdonSharp/Editor/UdonSharpExpressionCapture.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpExpressionCapture.cs
@@ -324,7 +324,7 @@ namespace UdonSharp
                 else
                 {
                     getIndexerUdonName = visitorContext.resolverContext.GetUdonMethodName(accessSymbol.symbolCsType.GetMethods(BindingFlags.Public | BindingFlags.Instance).Where(e => e.Name == "Get").First());
-                    elementType = accessSymbol.symbolCsType.GetElementType();
+                    elementType = accessSymbol.userCsType.GetElementType();
                 }
 
                 outSymbol = visitorContext.topTable.CreateUnnamedSymbol(elementType, SymbolDeclTypeFlags.Internal);
@@ -426,7 +426,7 @@ namespace UdonSharp
 
             // Special case for passing through user defined classes if they match
             if (sourceSymbol.IsUserDefinedBehaviour() && 
-                targetType.IsAssignableFrom(sourceSymbol.userCsType))
+                (targetType.IsAssignableFrom(sourceSymbol.userCsType) || (targetType.IsArray && targetType == sourceSymbol.userCsType)))
                 return sourceSymbol;
             
             // Special case for assigning objects to non-value types so we can assign and the output of things that return a generic object

--- a/Assets/UdonSharp/Editor/UdonSharpProgramAsset.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpProgramAsset.cs
@@ -168,8 +168,9 @@ public class <TemplateClassName> : UdonSharpBehaviour
         private object DrawFieldForType(string fieldName, string symbol, (object value, Type declaredType) publicVariable, ref bool dirty, bool enabled)
         {
             bool isArrayElement = fieldName != null;
-            FieldDefinition fieldDefinition;
-            fieldDefinitions.TryGetValue(symbol, out fieldDefinition);
+            FieldDefinition fieldDefinition = null;
+            if (fieldDefinitions != null)
+                fieldDefinitions.TryGetValue(symbol, out fieldDefinition);
 
             if (fieldName == null)
                 fieldName = ObjectNames.NicifyVariableName(symbol);
@@ -348,7 +349,7 @@ public class <TemplateClassName> : UdonSharpBehaviour
             bool isArray = publicVariable.declaredType.IsArray;
 
             FieldDefinition symbolField;
-            if (fieldDefinitions.TryGetValue(symbol, out symbolField))
+            if (fieldDefinitions != null && fieldDefinitions.TryGetValue(symbol, out symbolField))
             {
                 HideInInspector hideAttribute = symbolField.GetAttribute<HideInInspector>();
 

--- a/Assets/UdonSharp/Editor/UdonSharpProgramAsset.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpProgramAsset.cs
@@ -251,7 +251,7 @@ public class <TemplateClassName> : UdonSharpBehaviour
 
             objectRect = EditorGUI.PrefixLabel(objectRect, new GUIContent(fieldName));
 
-            currentUserScript = fieldDefinition.fieldSymbol.userBehaviourSource;
+            currentUserScript = fieldDefinition.userBehaviourSource;
 
             UnityEngine.Object objectFieldValue = (UnityEngine.Object)doObjectFieldMethod.Invoke(null, new object[] {
                 objectRect,

--- a/Assets/UdonSharp/Editor/UdonSharpProgramAsset.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpProgramAsset.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using UnityEditor;
 using UnityEngine;
+using UnityEngine.Experimental.UIElements;
 using VRC.Udon.Common.Interfaces;
 
 [assembly: UdonProgramSourceNewMenu(typeof(UdonSharp.UdonSharpProgramAsset), "Udon C# Program Asset")]
@@ -154,6 +156,193 @@ public class <TemplateClassName> : UdonSharpBehaviour
                     sourceCsScript = AssetDatabase.LoadAssetAtPath<MonoScript>(chosenFilePath);
                 }
             }
+        }
+
+        [NonSerialized]
+        private Dictionary<string, bool> foldoutStates = new Dictionary<string, bool>();
+
+        private object DrawFieldForType(string fieldName, string symbol, (object value, Type declaredType) publicVariable, ref bool dirty, bool enabled)
+        {
+            if (fieldName == null)
+                fieldName = ObjectNames.NicifyVariableName(symbol);
+
+            (object value, Type declaredType) = publicVariable;
+
+            if (declaredType.IsArray)
+            {
+                bool foldoutEnabled;
+
+                if (!foldoutStates.TryGetValue(symbol, out foldoutEnabled))
+                {
+                    foldoutStates.Add(symbol, false);
+                }
+
+                foldoutEnabled = EditorGUILayout.Foldout(foldoutEnabled, fieldName);
+                foldoutStates[symbol] = foldoutEnabled;
+
+                if (foldoutEnabled)
+                {
+                    EditorGUI.indentLevel++;
+
+                    Array valueArray = value as Array;
+
+                    EditorGUI.BeginChangeCheck();
+                    int newLength = EditorGUILayout.IntField("Size", valueArray.Length);
+
+                    // We need to resize the array
+                    if (EditorGUI.EndChangeCheck())
+                    {
+                        Array newArray = Activator.CreateInstance(declaredType, new object[] { newLength }) as Array;
+
+                        for (int i = 0; i < newLength && i < valueArray.Length; ++i)
+                        {
+                            newArray.SetValue(valueArray.GetValue(i), i);
+                        }
+
+                        dirty = true;
+
+                        EditorGUI.indentLevel--;
+                        return newArray;
+                    }
+
+                    Type elementType = declaredType.GetElementType();
+
+                    for (int i = 0; i < valueArray.Length; ++i)
+                    {
+                        var elementData = (valueArray.GetValue(i), elementType);
+
+                        EditorGUI.BeginChangeCheck();
+                        object newArrayVal = DrawFieldForType($"Element {i}", $"{symbol}_element{i}", elementData, ref dirty, enabled);
+
+                        if (EditorGUI.EndChangeCheck())
+                        {
+                            valueArray.SetValue(newArrayVal, i);
+                            dirty = true;
+                        }
+                    }
+
+                    EditorGUI.indentLevel--;
+
+                    return valueArray;
+                }
+            }
+            else if (typeof(UnityEngine.Object).IsAssignableFrom(declaredType))
+            {
+                return EditorGUILayout.ObjectField(fieldName, (UnityEngine.Object)value, declaredType, true);
+            }
+            else if (declaredType == typeof(string))
+            {
+                return EditorGUILayout.TextField(fieldName, (string)value);
+            }
+            else if (declaredType == typeof(float))
+            {
+                return EditorGUILayout.FloatField(fieldName, (float?)value ?? default);
+            }
+            else if (declaredType == typeof(double))
+            {
+                return EditorGUILayout.DoubleField(fieldName, (double?)value ?? default);
+            }
+            else if (declaredType == typeof(int))
+            {
+                return EditorGUILayout.IntField(fieldName, (int?)value ?? default);
+            }
+            else if (declaredType == typeof(long))
+            {
+                return EditorGUILayout.LongField(fieldName, (long?)value ?? default);
+            }
+            else if (declaredType == typeof(bool))
+            {
+                return EditorGUILayout.Toggle(fieldName, (bool?)value ?? default);
+            }
+            else if (declaredType == typeof(Vector2))
+            {
+                return EditorGUILayout.Vector2Field(fieldName, (Vector2?)value ?? default);
+            }
+            else if (declaredType == typeof(Vector3))
+            {
+                return EditorGUILayout.Vector3Field(fieldName, (Vector3?)value ?? default);
+            }
+            else if (declaredType == typeof(Vector4))
+            {
+                return EditorGUILayout.Vector4Field(fieldName, (Vector4?)value ?? default);
+            }
+            else if (declaredType == typeof(Color))
+            {
+                return EditorGUILayout.ColorField(fieldName, (Color?)value ?? default);
+            }
+            else if (declaredType == typeof(Color32))
+            {
+                return (Color32)EditorGUILayout.ColorField(fieldName, (Color32?)value ?? default);
+            }
+            else if (declaredType == typeof(Quaternion))
+            {
+                Quaternion quatVal = (Quaternion?)value ?? default;
+                Vector4 newQuat = EditorGUILayout.Vector4Field(fieldName, new Vector4(quatVal.x, quatVal.y, quatVal.z, quatVal.w));
+                return new Quaternion(newQuat.x, newQuat.y, newQuat.z, newQuat.w);
+            }
+            else if (declaredType == typeof(Bounds))
+            {
+                return EditorGUILayout.BoundsField(fieldName, (Bounds?)value ?? default);
+            }
+            else if (declaredType == typeof(ParticleSystem.MinMaxCurve))
+            {
+                // This is just matching the standard Udon editor's capability at the moment, I want to eventually switch it to use the proper curve editor, but that will take a chunk of work
+                ParticleSystem.MinMaxCurve minMaxCurve = (ParticleSystem.MinMaxCurve?)value ?? default;
+
+                EditorGUILayout.BeginVertical();
+                EditorGUILayout.LabelField(fieldName);
+                EditorGUI.indentLevel++;
+                minMaxCurve.curveMultiplier = EditorGUILayout.FloatField("Multiplier", minMaxCurve.curveMultiplier);
+                minMaxCurve.curveMin = EditorGUILayout.CurveField("Min Curve", minMaxCurve.curveMin);
+                minMaxCurve.curveMax = EditorGUILayout.CurveField("Max Curve", minMaxCurve.curveMax);
+
+                EditorGUI.indentLevel--;
+
+                EditorGUILayout.EndVertical();
+
+                return minMaxCurve;
+            }
+            else if (declaredType.IsEnum)
+            {
+                return EditorGUILayout.EnumPopup(fieldName, (Enum)(value ?? Activator.CreateInstance(declaredType)));
+            }
+            else if (declaredType == typeof(System.Type))
+            {
+                string typeName = value != null ? ((Type)value).FullName : "null";
+                EditorGUILayout.LabelField(fieldName, typeName);
+            }
+            else if (declaredType == typeof(Gradient))
+            {
+                return EditorGUILayout.GradientField(fieldName, (Gradient)value);
+            }
+            else if (declaredType == typeof(AnimationCurve))
+            {
+                return EditorGUILayout.CurveField(fieldName, (AnimationCurve)value);
+            }
+            else
+            {
+                EditorGUILayout.LabelField($"{fieldName}: no drawer for type {declaredType}");
+
+                return value;
+            }
+
+            return value;
+        }
+
+        protected override void DrawFieldForTypeString(string symbol, ref (object value, Type declaredType) publicVariable, ref bool dirty, bool enabled)
+        {
+            EditorGUI.BeginDisabledGroup(!enabled);
+
+            EditorGUI.BeginChangeCheck();
+            object newValue = DrawFieldForType(null, symbol, publicVariable, ref dirty, enabled);
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                dirty = true;
+                publicVariable.value = newValue;
+            }
+
+            EditorGUI.EndDisabledGroup();
         }
     }
     

--- a/Assets/UdonSharp/Editor/UdonSharpResolverContext.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpResolverContext.cs
@@ -262,6 +262,15 @@ namespace UdonSharp
             return null;
         }
 
+        public string SanitizeTypeName(string typeName)
+        {
+            return typeName.Replace(",", "")
+                           .Replace(".", "")
+                           .Replace("[]", "Array")
+                           .Replace("&", "Ref")
+                           .Replace("+", "");
+        }
+
         /// <summary>
         /// Verifies that Udon supports the given type and resolves the type name used to reference it in Udon
         /// </summary>

--- a/Assets/UdonSharp/Editor/UdonSharpResolverContext.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpResolverContext.cs
@@ -778,7 +778,7 @@ namespace UdonSharp
                     typeName = $"Variable_{typeName}";
                     break;
                 default:
-                    return true;
+                    break;
             }
 
             return nodeDefinitionLookup.Contains(typeName);

--- a/Assets/UdonSharp/Editor/UdonSharpSymbolTable.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpSymbolTable.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+using VRC.Udon.Serialization.OdinSerializer;
 
 namespace UdonSharp
 {
@@ -19,8 +20,10 @@ namespace UdonSharp
         //UserType = 128, // this symbol is a user defined behaviour that is stored as an UdonBehaviour
     }
 
+    [Serializable]
     public class SymbolDefinition
     {
+        [OdinSerialize]
         private System.Type internalType; 
 
         // The type of the symbol from the C# side

--- a/Assets/UdonSharp/Editor/UdonSharpSymbolTable.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpSymbolTable.cs
@@ -68,7 +68,9 @@ namespace UdonSharp
         //public bool IsUserDefinedBehaviour() { return declarationType.HasFlag(SymbolDeclTypeFlags.UserType); }
         public bool IsUserDefinedBehaviour()
         {
-            return internalType.IsSubclassOf(typeof(UdonSharpBehaviour)) || (internalType.IsArray && internalType.GetElementType().IsSubclassOf(typeof(UdonSharpBehaviour)));
+            return internalType == typeof(UdonSharpBehaviour) ||
+                   internalType.IsSubclassOf(typeof(UdonSharpBehaviour)) || 
+                  (internalType.IsArray && (internalType.GetElementType().IsSubclassOf(typeof(UdonSharpBehaviour)) || internalType.GetElementType() == typeof(UdonSharpBehaviour)));
         }
     }
 
@@ -375,7 +377,7 @@ namespace UdonSharp
             System.Type typeForName = resolvedSymbolType;
             if (resolvedSymbolType.IsSubclassOf(typeof(UdonSharpBehaviour)))
                 typeForName = typeof(VRC.Udon.UdonBehaviour);
-            else if (resolvedSymbolType.IsArray && resolvedSymbolType.GetElementType().IsSubclassOf(typeof(UdonSharpBehaviour)))
+            else if (resolvedSymbolType.IsArray && (resolvedSymbolType.GetElementType() == typeof(UdonSharpBehaviour) || resolvedSymbolType.GetElementType().IsSubclassOf(typeof(UdonSharpBehaviour))))
                 typeForName = typeof(Component[]); // Hack because VRC doesn't expose UdonBehaviour array type
 
             string udonTypeName = resolver.GetUdonTypeName(typeForName);

--- a/Assets/UdonSharp/Editor/UdonSharpSymbolTable.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpSymbolTable.cs
@@ -42,8 +42,6 @@ namespace UdonSharp
 
         public System.Type userCsType { get { return internalType; } }
 
-        public UnityEditor.MonoScript userBehaviourSource;
-
         // How the symbol was created
         public SymbolDeclTypeFlags declarationType;
 
@@ -85,8 +83,6 @@ namespace UdonSharp
 
         private Dictionary<string, int> namedSymbolCounters;
 
-        public ASTVisitorContext visitorContext { get; set; }
-
         public SymbolTable GetGlobalSymbolTable()
         {
             SymbolTable currentTable = this;
@@ -97,7 +93,7 @@ namespace UdonSharp
             return currentTable;
         }
 
-        public SymbolTable(ResolverContext resolverContext, SymbolTable parentTable, ASTVisitorContext visitorContextIn = null)
+        public SymbolTable(ResolverContext resolverContext, SymbolTable parentTable)
         {
             resolver = resolverContext;
             parentSymbolTable = parentTable;
@@ -109,8 +105,6 @@ namespace UdonSharp
 
             symbolDefinitions = new List<SymbolDefinition>();
             namedSymbolCounters = new Dictionary<string, int>();
-
-            visitorContext = visitorContextIn;
         }
 
         protected int IncrementUniqueNameCounter(string symbolName)
@@ -376,18 +370,6 @@ namespace UdonSharp
             symbolDefinition.symbolOriginalName = symbolName;
             symbolDefinition.symbolResolvedTypeName = udonTypeName;
             symbolDefinition.symbolUniqueName = uniqueSymbolName;
-
-            if (symbolDefinition.IsUserDefinedBehaviour() && visitorContext != null)
-            {
-                foreach (ClassDefinition classDefinition in visitorContext.externClassDefinitions)
-                {
-                    if (classDefinition.userClassType == symbolDefinition.userCsType)
-                    {
-                        symbolDefinition.userBehaviourSource = classDefinition.classScript;
-                        break;
-                    }
-                }
-            }
 
             if (hasGlobalDeclaration)
             {

--- a/Assets/UdonSharp/Editor/UdonSharpSymbolTable.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpSymbolTable.cs
@@ -327,8 +327,9 @@ namespace UdonSharp
         /// <param name="symbolName"></param>
         /// <param name="resolvedSymbolType"></param>
         /// <param name="declType"></param>
+        /// <param name="appendType">Used to disable redundant type append from unnamed variable allocations</param>
         /// <returns></returns>
-        private SymbolDefinition CreateNamedSymbolInternal(string symbolName, System.Type resolvedSymbolType, SymbolDeclTypeFlags declType)
+        private SymbolDefinition CreateNamedSymbolInternal(string symbolName, System.Type resolvedSymbolType, SymbolDeclTypeFlags declType, bool appendType = true)
         {
             if (resolvedSymbolType == null || symbolName == null)
                 throw new System.ArgumentNullException();
@@ -359,6 +360,12 @@ namespace UdonSharp
 
             if (!declType.HasFlag(SymbolDeclTypeFlags.Public) && !declType.HasFlag(SymbolDeclTypeFlags.Private))
             {
+                if (appendType)
+                {
+                    string sanitizedName = resolver.SanitizeTypeName(resolvedSymbolType.Name);
+                    uniqueSymbolName += $"_{sanitizedName}";
+                }
+
                 if (hasGlobalDeclaration)
                     uniqueSymbolName = $"__{IncrementGlobalNameCounter(uniqueSymbolName)}_{uniqueSymbolName}";
                 else
@@ -460,7 +467,7 @@ namespace UdonSharp
             if (typeName == null)
                 return null;
 
-            return CreateNamedSymbolInternal(typeName, type, declType | SymbolDeclTypeFlags.Internal | (IsGlobalSymbolTable ? 0 : SymbolDeclTypeFlags.Local));
+            return CreateNamedSymbolInternal(typeName, type, declType | SymbolDeclTypeFlags.Internal | (IsGlobalSymbolTable ? 0 : SymbolDeclTypeFlags.Local), false);
         }
 
         public List<SymbolTable> GetAllChildSymbolTables()

--- a/Assets/UdonSharp/Editor/UdonSharpUtils.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpUtils.cs
@@ -200,9 +200,13 @@ namespace UdonSharp
             typeof(char),
             typeof(byte), typeof(sbyte),
             typeof(int), typeof(uint),
-            typeof(long),
+            typeof(long), typeof(ulong),
             typeof(float), typeof(double),
             typeof(short), typeof(ushort),
+            typeof(string),
+            typeof(UnityEngine.Vector2), typeof(UnityEngine.Vector3), typeof(UnityEngine.Vector4),
+            typeof(UnityEngine.Quaternion),
+            typeof(UnityEngine.Color32), typeof(UnityEngine.Color),
         };
 
         public static bool IsUdonSyncedType(System.Type type)

--- a/Assets/UdonSharp/Editor/UdonSharpUtils.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpUtils.cs
@@ -209,5 +209,16 @@ namespace UdonSharp
         {
             return udonSyncTypes.Contains(type);
         }
+        
+        public static void LogBuildError(string message, string filePath, int line, int character)
+        {
+            MethodInfo buildErrorLogMethod = typeof(UnityEngine.Debug).GetMethod("LogPlayerBuildError", BindingFlags.NonPublic | BindingFlags.Static);
+
+            buildErrorLogMethod.Invoke(null, new object[] {
+                        $"[UdonSharp] {message}",
+                        filePath,
+                        line + 1,
+                        character });
+        }
     }
 }

--- a/Assets/UdonSharp/Plugins/Microsoft.CodeAnalysis.CSharp.dll.meta
+++ b/Assets/UdonSharp/Plugins/Microsoft.CodeAnalysis.CSharp.dll.meta
@@ -8,20 +8,80 @@ PluginImporter:
   defineConstraints: []
   isPreloaded: 0
   isOverridable: 0
-  isExplicitlyReferenced: 0
+  isExplicitlyReferenced: 1
   validateReferences: 1
   platformData:
   - first:
+      '': Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux: 1
+        Exclude Linux64: 1
+        Exclude LinuxUniversal: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+  - first:
       Any: 
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor
     second:
-      enabled: 0
+      enabled: 1
       settings:
         DefaultValueInitialized: true
+  - first:
+      Facebook: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Facebook: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Linux
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: LinuxUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
   - first:
       Windows Store Apps: WindowsStoreApps
     second:

--- a/Assets/UdonSharp/Plugins/Microsoft.CodeAnalysis.dll.meta
+++ b/Assets/UdonSharp/Plugins/Microsoft.CodeAnalysis.dll.meta
@@ -8,20 +8,80 @@ PluginImporter:
   defineConstraints: []
   isPreloaded: 0
   isOverridable: 0
-  isExplicitlyReferenced: 0
+  isExplicitlyReferenced: 1
   validateReferences: 1
   platformData:
   - first:
+      '': Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux: 1
+        Exclude Linux64: 1
+        Exclude LinuxUniversal: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+  - first:
       Any: 
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor
     second:
-      enabled: 0
+      enabled: 1
       settings:
         DefaultValueInitialized: true
+  - first:
+      Facebook: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Facebook: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Linux
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: LinuxUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
   - first:
       Windows Store Apps: WindowsStoreApps
     second:

--- a/Assets/UdonSharp/Plugins/System.Collections.Immutable.dll.meta
+++ b/Assets/UdonSharp/Plugins/System.Collections.Immutable.dll.meta
@@ -8,20 +8,80 @@ PluginImporter:
   defineConstraints: []
   isPreloaded: 0
   isOverridable: 0
-  isExplicitlyReferenced: 0
+  isExplicitlyReferenced: 1
   validateReferences: 1
   platformData:
   - first:
+      '': Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux: 1
+        Exclude Linux64: 1
+        Exclude LinuxUniversal: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+  - first:
       Any: 
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor
     second:
-      enabled: 0
+      enabled: 1
       settings:
         DefaultValueInitialized: true
+  - first:
+      Facebook: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Facebook: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Linux
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: LinuxUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
   - first:
       Windows Store Apps: WindowsStoreApps
     second:

--- a/Assets/UdonSharp/Plugins/System.Reflection.Metadata.dll.meta
+++ b/Assets/UdonSharp/Plugins/System.Reflection.Metadata.dll.meta
@@ -8,20 +8,80 @@ PluginImporter:
   defineConstraints: []
   isPreloaded: 0
   isOverridable: 0
-  isExplicitlyReferenced: 0
+  isExplicitlyReferenced: 1
   validateReferences: 1
   platformData:
   - first:
+      '': Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux: 1
+        Exclude Linux64: 1
+        Exclude LinuxUniversal: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+  - first:
       Any: 
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor
     second:
-      enabled: 0
+      enabled: 1
       settings:
         DefaultValueInitialized: true
+  - first:
+      Facebook: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Facebook: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Linux
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: LinuxUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
   - first:
       Windows Store Apps: WindowsStoreApps
     second:

--- a/Assets/UdonSharp/Scripts/UdonSharpBehaviour.cs
+++ b/Assets/UdonSharp/Scripts/UdonSharpBehaviour.cs
@@ -10,7 +10,7 @@ namespace UdonSharp
         public void SetProgramVariable(string name, object value) { }
         public void SendCustomEvent(string eventName) { }
         public void SendCustomNetworkEvent(NetworkEventTarget target, string eventName) { }
-        public static GameObject VRCInstantiate(GameObject original) { return null; }
+        public static GameObject VRCInstantiate(GameObject original) { return Instantiate(original); }
 
         // Method stubs for auto completion
         public virtual void Interact() { }

--- a/Assets/UdonSharp/Scripts/UdonSharpRuntimeAssembly.asmdef
+++ b/Assets/UdonSharp/Scripts/UdonSharpRuntimeAssembly.asmdef
@@ -1,0 +1,12 @@
+{
+    "name": "UdonSharp.Runtime",
+    "references": [],
+    "optionalUnityReferences": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": []
+}

--- a/Assets/UdonSharp/Scripts/UdonSharpRuntimeAssembly.asmdef.meta
+++ b/Assets/UdonSharp/Scripts/UdonSharpRuntimeAssembly.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 99835874ee819da44948776e0df4ff1d
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR adds type aliasing that allows the compiler to know about an underlying user defined type, but store it as a Udon-compatible UdonBehaviour or Component array. This only works for classes that inherit from UdonSharpBehaviour at the moment, but may be extended in the future to support jagged arrays or user classes that are not behaviours.

- Add the ability to call user defined methods and access fields on other UdonSharpBehaviours. 
- Allow the user to store references to their custom UdonSharpBehaviours and support arrays of them. 
- Add basic custom inspector override that has wider support for types
- This does not handle type checking against user defined types or getting components of the user defined type yet, that is the next thing to work on.